### PR TITLE
fixed structured data check + added tests

### DIFF
--- a/destination.go
+++ b/destination.go
@@ -142,12 +142,15 @@ func (d *Destination) handleDelete(ctx context.Context, record sdk.Record) error
 
 // validateStructuredRecord return an error if the record key or payload is not structured.
 func (d *Destination) validateStructuredRecord(record sdk.Record) error {
-	// check that payload is structured
-	if _, ok := record.Payload.After.(sdk.StructuredData); !ok {
-		return fmt.Errorf("payload should be structured data")
+	// delete operation doesn't need a structured payload
+	if record.Operation != sdk.OperationDelete {
+		// check that payload is structured
+		if _, ok := record.Payload.After.(sdk.StructuredData); !ok {
+			return fmt.Errorf("payload should be structured data")
+		}
 	}
-	// check that key is structured
-	if _, ok := record.Payload.After.(sdk.StructuredData); !ok {
+	// check that key is structured for all operations
+	if _, ok := record.Key.(sdk.StructuredData); !ok {
 		return fmt.Errorf("key should be structured data")
 	}
 	return nil

--- a/destination_integration_test.go
+++ b/destination_integration_test.go
@@ -112,7 +112,8 @@ func TestDestination_Write(t *testing.T) {
 			// this record is already in the table
 			Key: sdk.StructuredData{"id1": "1", "id2": 1},
 			Payload: sdk.Change{
-				After: sdk.StructuredData{},
+				// rawData payload for a delete operation should be fine
+				After: sdk.RawData{},
 			},
 		},
 	},
@@ -135,6 +136,85 @@ func TestDestination_Write(t *testing.T) {
 				is.Equal(tt.record.Payload.After, got)
 			case sdk.OperationDelete:
 				is.Equal(err, gocql.ErrNotFound)
+			}
+		})
+	}
+}
+
+func TestDestination_Data_Format(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	session := simpleConnect(t, map[string]string{
+		"host": testHost,
+		"port": testPort,
+	})
+	table := setupTest(t, session)
+
+	destination := NewDestination()
+	err := destination.Configure(ctx, map[string]string{
+		"host":     testHost,
+		"port":     testPort,
+		"keyspace": testKeyspace,
+		"table":    table,
+	})
+	is.NoErr(err)
+	err = destination.Open(ctx)
+	is.NoErr(err)
+	defer func() {
+		err := destination.Teardown(ctx)
+		is.NoErr(err)
+	}()
+
+	testCases := []struct {
+		name         string
+		record       sdk.Record
+		wantErr      bool
+		errSubString string
+	}{{
+		name: "rawData payload for a create operation should fail",
+		record: sdk.Record{
+			Operation: sdk.OperationCreate,
+			Key:       sdk.StructuredData{"id1": "1", "id2": 1},
+			Payload: sdk.Change{
+				After: sdk.RawData{},
+			},
+		},
+		wantErr:      true,
+		errSubString: "payload should be structured data",
+	}, {
+		name: "rawData key should fail",
+		record: sdk.Record{
+			Operation: sdk.OperationCreate,
+			Key:       sdk.RawData("id:1"),
+			Payload: sdk.Change{
+				After: sdk.StructuredData{},
+			},
+		},
+		wantErr:      true,
+		errSubString: "key should be structured data",
+	}, {
+		name: "rawData payload for a delete operation should pass",
+		record: sdk.Record{
+			Operation: sdk.OperationDelete,
+			Key:       sdk.StructuredData{"id1": "1", "id2": 1},
+			Payload: sdk.Change{
+				After: sdk.RawData{},
+			},
+		},
+		wantErr: false,
+	},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			i, err := destination.Write(ctx, []sdk.Record{tt.record})
+			if tt.wantErr {
+				is.True(err != nil)
+				is.True(strings.Contains(err.Error(), tt.errSubString))
+				is.Equal(i, 0)
+			} else {
+				is.NoErr(err)
+				is.Equal(i, 1)
 			}
 		})
 	}

--- a/destination_integration_test.go
+++ b/destination_integration_test.go
@@ -127,7 +127,7 @@ func TestDestination_Write(t *testing.T) {
 			i, err := destination.Write(ctx, []sdk.Record{tt.record})
 			is.NoErr(err)
 			is.Equal(i, 1)
-			time.Sleep(1 * time.Second)
+			time.Sleep(time.Second)
 
 			got, err := queryTestTable(session, table, id1, id2)
 			switch tt.record.Operation {

--- a/destination_integration_test.go
+++ b/destination_integration_test.go
@@ -127,7 +127,7 @@ func TestDestination_Write(t *testing.T) {
 			i, err := destination.Write(ctx, []sdk.Record{tt.record})
 			is.NoErr(err)
 			is.Equal(i, 1)
-			time.Sleep(200 * time.Millisecond)
+			time.Sleep(1 * time.Second)
 
 			got, err := queryTestTable(session, table, id1, id2)
 			switch tt.record.Operation {

--- a/query_builder.go
+++ b/query_builder.go
@@ -54,7 +54,7 @@ func (q *QueryBuilder) BuildUpdateQuery(rec sdk.Record, table string) (string, [
 
 // BuildDeleteQuery takes a record, and returns the delete query statement and values representing that record.
 func (q *QueryBuilder) BuildDeleteQuery(rec sdk.Record, table string) (string, []interface{}) {
-	keyCols, keyVals, _, _ := q.getColumnsAndValues(rec.Key.(sdk.StructuredData), rec.Payload.After.(sdk.StructuredData))
+	keyCols, keyVals, _, _ := q.getColumnsAndValues(rec.Key.(sdk.StructuredData), nil)
 	whereStatement := q.pairValuesWithPlaceholder(keyCols, whereStatementSeparator)
 	query := fmt.Sprintf(deleteQuery, table, whereStatement)
 	return query, keyVals


### PR DESCRIPTION
### Description
 1. structured data check was done on payload twice (instead of payload and key)
 2. a delete operation should ignore payload and pass even if payload is rawData
 ++ added a test for data formats

### Quick checks:

- [ ] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-cassandra/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.