### PR TITLE
Remove Docker from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,10 +17,3 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "go.mod:"
-
-  - package-ecosystem: "docker"
-    directory: "/test"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "docker:"


### PR DESCRIPTION
### Description

Sorry for the roller coaster! Dependabot doesn't support updates in Docker Compose, I forgot about that.

### Quick checks:

- [ ] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-cassandra/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.